### PR TITLE
Add RFB 003.889 (macOS Screen Sharing) protocol support

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -341,6 +341,10 @@ export class VncClient extends EventEmitter {
 			this._log('Sending 3.8', true);
 			this._connection?.write(consts.versionString.V3_008);
 			this._version = '3.8';
+		} else if (ver === consts.versionString.V3_889) {
+			this._log('Sending 3.889 (must be a Mac)', true);
+			this._connection?.write(consts.versionString.V3_889);
+			this._version = '3.8';
 		} else {
 			this._log(`Unknown Protocol Version (not an RFB server?)`, true);
 			this._log(ver, true);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -21,7 +21,8 @@ export const consts = {
 		V3_003: 'RFB 003.003\n',
 		V3_006: 'RFB 003.006\n',
 		V3_007: 'RFB 003.007\n',
-		V3_008: 'RFB 003.008\n'
+		V3_008: 'RFB 003.008\n',
+		V3_889: 'RFB 003.889\n'
 	},
 	encodings: {
 		raw: 0,


### PR DESCRIPTION
macOS Screen Sharing uses RFB protocol version 003.889 instead of 003.008. This patch adds the version string and handles it the same way as 003.008, allowing the VNC client to connect to macOS Screen Sharing servers.

Fixes connection failure when connecting to macOS Screen Sharing via VNC.